### PR TITLE
Corrections for Bukhari book 65 part 5

### DIFF
--- a/Output/Bukhari/65p5.txt
+++ b/Output/Bukhari/65p5.txt
@@ -26,7 +26,7 @@ When 'Uyaina entered upon him, he said, "Beware! O the son of Al-Khattab! By All
 Thereupon `Umar became so furious that he intended to harm him, but Al-Hurr said, "O chief of the Believers! Allah said to His Prophet: 'Hold to forgiveness; command what is right; and leave (don't punish) the foolish,' (Surah 7 : Ayah 199) and this (i.e. 'Uyaina) is one of the foolish."
 By Allah, `Umar did not overlook that Verse when Al-Hurr recited it before him; he observed (the orders of) Allah's Book strictly.
 Hadith - 165
-Narrated `Abdullah bin Az-Zubair: (The Verse) "Hold to forgiveness; command what is right..." was revealed by Allah except in connection with the character of the people.
+Narrated `Abdullah bin Az-Zubair: (The Verse) "Hold to forgiveness; command what is right..." was not revealed by Allah except in connection with the character of the people.
 Hadith - 166
 Abdullah bin Az-Zubair said: Allah ordered His Prophet to forgive the people their misbehavior (towards him).
 Surah Al-Anfal (The Spoils of War)
@@ -59,7 +59,7 @@ Ibn `Umar said (to him), "And do you understand what an affliction is? Muhammad 
 Hadith - 174
 Narrated Ibn `Abbas: When the Verse: "If there are twenty steadfast amongst you, they will overcome two hundred," (Surah 8 : Ayah 65) was revealed, then it became obligatory for the Muslims that one (Muslim) should not flee from ten (non-Muslims).
 Sufyan (the sub-narrator) once said, "Twenty (Muslims) should not flee before two hundred (non Muslims)."
-Then there was revealed: 'But now Allah has lightened your (task)...' (Surah 8 : Ayah 66). So it became obligatory that one-hundred (Muslims) should not flee before two hundred (non-muslims).
+Then there was revealed: 'But now Allah has lightened your (task)...' (Surah 8 : Ayah 66). So it became obligatory that one-hundred (Muslims) should not flee before two hundred (non-Muslims).
 (Once Sufyan said extra, "The Verse: 'Urge the believers to the fight. If there are twenty steadfast amongst you (Muslims)...' was revealed.) Sufyan said, "Ibn Shubruma said, 'I see that this order is applicable to the obligation of enjoining good and forbidding evil.'"
 Hadith - 175
 Narrated Ibn `Abbas: When the Verse: 'If there are twenty steadfast amongst you (Muslims), they will overcome two-hundred (non-Muslims),' was revealed, it became hard on the Muslims when it became compulsory that one Muslim ought not to flee (in war) before ten (non-Muslims).
@@ -67,11 +67,11 @@ So (Allah) lightened the order by revealing: '(But) now Allah has lightened your
 So when Allah reduced the number of enemies which Muslims should withstand, their patience and perseverance against the enemy decreased as much as their task was lightened for them.
 Surah At-Tawbah (The Repentance)
 Hadith - 176
-Narrated Al-Bara: The last Verse that was revealed was: 'They ask you for a legal verdict: Say: Allah directs (thus) about Al-Kalalah (those who leave no descendants or ascendants as heirs).' And the last Surah which was revealed was Baraatun. (Surah 9)
+Narrated Al-Bara: The last Verse that was revealed was: 'They ask you for a legal verdict. Say: Allah directs (thus) about Al-Kalalah (those who leave no descendants or ascendants as heirs).' And the last Surah which was revealed was Baraatun. (Surah 9)
 Hadith - 177
 Narrated Humaid bin `Abdur-Rahman: Abu Huraira said, "During that Hajj (in which Abu Bakr was the chief of the pilgrims) Abu Bakr sent me along with announcers on the Day of Nahr (10th of Dhul-Hijja) in Mina to announce: "No pagans shall perform Hajj after this year, and none shall perform the Tawaf around the Ka`ba in a naked state."
 Humaid bin `Abdur Rahman added: Then Allah's Messenger (ﷺ) sent `Ali bin Abi Talib (after Abu Bakr) and ordered him to recite aloud in public Surat Bara'a.
-Abu Huraira added, "So `Ali, along with us, recited Bara'a (loudly) before the people at Mina on the Day of Nahr and announced; "No pagan shall perform Hajj after this year, and none shall perform the Tawaf around the Ka`ba in a naked state."
+Abu Huraira added, "So `Ali, along with us, recited Bara'a (loudly) before the people at Mina on the Day of Nahr and announced: "No pagan shall perform Hajj after this year, and none shall perform the Tawaf around the Ka`ba in a naked state."
 Hadith - 178
 Narrated Humaid bin `Abdur Rahman: Abu Huraira said, "Abu Bakr sent me in that Hajj in which he was the chief of the pilgrims, along with the announcers whom he sent on the Day of Nahr to announce at Mina: "No pagan shall perform Hajj after this year, and none shall perform the Tawaf around the Ka`ba in a naked state."
 Humaid added: That the Prophet (ﷺ) sent `Ali bin Abi Talib (after Abu Bakr) and ordered him to recite aloud in public Surat-Bara'a.
@@ -87,7 +87,7 @@ Hadith - 181
 Narrated Abu Huraira: Allah's Messenger (ﷺ) said, "The Kanz (money, the Zakat of which is not paid) of anyone of you will appear in the form of bald-headed poisonous male snake on the Day of Resurrection."
 Hadith - 182
 Narrated Zaid bin Wahb: I passed by (visited) Abu Dhar at Ar-Rabadha and said to him, "What has brought you to this land?" He said, "We were at Sham and I recited the Verse: 'They who hoard up gold and silver and spend them not in the way of Allah; announce to them a painful torment,' (Surah 9 : Ayah 34) whereupon Muawiya said, 'This Verse is not for us, but for the people of the Scripture.'
-Then I said, 'But it is both for us (Muslim) and for them.'"
+Then I said, 'But it is both for us (Muslims) and for them.'"
 Hadith - 183
 Narrated Khãlid bin Aslam: We went out with 'Abdullãh bin 'Umar and he said, "This (Verse) was revealed before the prescription of Zakat, and when Zakãt was prescribed, Allah made it a means of purifying one's wealth."
 Hadith - 184
@@ -99,15 +99,15 @@ He said, "What do you think of two, the third of whom is Allah?"
 Hadith - 186
 Narrated Ibn Abi Mulaika: When there happened the disagreement between Ibn Az-Zubair and Ibn `Abbas, I said (to the latter), "(Why don't you take the oath of allegiance to him as) his father is Az-Zubair, and his mother is Asma', and his aunt is `Aisha, and his maternal grandfather is Abu Bakr, and his grandmother is Safiya?"
 Hadith - 187
-Narrated Ibn Abi Mulaika: There was a disagreement between them (i.e. Ibn `Abbas and Ibn Az-Zubair) so I went to Ibn `Abbas in the morning and said (to him), "Do you want to fight against Ibn Az-Zubair and thus make lawful what Allah has made unlawful (i.e. fighting in Mecca?"
+Narrated Ibn Abi Mulaika: There was a disagreement between them (i.e. Ibn `Abbas and Ibn Az-Zubair) so I went to Ibn `Abbas in the morning and said (to him), "Do you want to fight against Ibn Az-Zubair and thus make lawful what Allah has made unlawful (i.e. fighting in Mecca)?"
 Ibn `Abbas said, "Allah forbid! Allah ordained that Ibn Az-Zubair and Bani Umaiya would permit (fighting in Mecca), but by Allah, I will never regard it as permissible."
 Ibn `Abbas added, "The people asked me to take the oath of allegiance to Ibn Az-Zubair.
 I said, 'He is really entitled to assume authority, for his father - Az-Zubair - was the helper of the Prophet (ﷺ), his (maternal) grandfather - Abu Bakr - was (the Prophet's) companion in the cave, his mother - Asma' - was Dhatun-Nitaq, his aunt - `Aisha - was the mother of the Believers, his paternal aunt - Khadija - was the wife of the Prophet (ﷺ), and the paternal aunt of the Prophet (ﷺ) was his grandmother.
-He himself is pious and chaste in Islam, well versed in the Knowledge of the Qur'an. By Allah! (Really, I left my relatives, Bani Umaiya for his sake though) they are my close relatives, and if they should be my rulers, they are equally apt to be so and are descended from a noble family."
+He himself is pious and chaste in Islam, well versed in the Knowledge of the Qur'an. By Allah! (Really, I left my relatives, Bani Umaiya for his sake though) they are my close relatives, and if they should be my rulers, they are equally apt to be so and are descended from a noble family.'"
 Hadith - 188
 Narrated Ibn Abi Mulaika: We entered upon Ibn `Abbas and he said, "Are you not astonished at Ibn Az-Zubair's assuming the caliphate?"
 I said (to myself), "I will support him and speak of his good traits as I did not do even for Abu Bakr and `Umar, though they were more entitled to receive all good than he was."
-I said, "He (i.e Ibn Az-Zubair) is the son of the aunt of the Prophet (ﷺ) and the son of Az-Zubair, and the grandson of Abu Bakr and the son of Khadija's brother, and the son of `Aisha's sister."
+I said, "He (i.e. Ibn Az-Zubair) is the son of the aunt of the Prophet (ﷺ) and the son of Az-Zubair, and the grandson of Abu Bakr, and the son of Khadija's brother, and the son of `Aisha's sister."
 Nevertheless, he considers himself to be superior to me and does not want me to be one of his friends.
 So I said, "I never expected that he would refuse my offer to support him, and I don't think he intends to do me any good, therefore, if my cousins should inevitably be my rulers, it will be better for me to be ruled by them than by some others."
 Hadith - 189
@@ -118,19 +118,19 @@ Narrated Abu Mas`ud: When we were ordered to give alms, we began to work as port
 So the hypocrites said, "Allah is not in need of the alms of this (i.e. Abu `Aqil); and this other person did not give alms but for showing off."
 Then Allah revealed: 'Those who criticize such of the Believers who give charity voluntarily and those who could not find to give in charity except what is available to them...' (Surah 9: Ayah 79)
 Hadith - 191
-Narrated Shaqiq: Abu Mas`ud Al-Ansari said, "Allah's Messenger (ﷺ) used to order us to give alms. So one of us would exert himself to earn one Mud (special measure of wheat or dates, etc) to give in charity; while today one of us may have one hundred thousand."
+Narrated Shaqiq: Abu Mas`ud Al-Ansari said, "Allah's Messenger (ﷺ) used to order us to give alms. So one of us would exert himself to earn one Mudd (special measure of wheat or dates, etc) to give in charity; while today one of us may have one hundred thousand."
 Shaqiq said: As if Abu Masud referred to himself.
 Hadith - 192
 Narrated Ibn `Abbas: When `Abdullah bin 'Ubai died, his son `Abdullah bin `Abdullah came to Allah's Messenger (ﷺ) and asked him to give him his shirt, in order to shroud his father in it.
 He gave it to him and then `Abdullah asked the Prophet (ﷺ) to offer the funeral prayer for him (his father).
-Allah's Messenger (ﷺ) got up to offer the funeral prayer for him, but `Umar got up too and got hold of the garment of Allah's Messenger (ﷺ) and said, "O Allah's Messenger (ﷺ)! Will you offer the funeral prayer for him though your Lord has forbidden you to offer the prayer for him."
-Allah's Messenger (ﷺ) said, "But Allah has given me the choice by saying: '(Whether you) ask forgiveness for them, or do not ask forgiveness for them; even if you ask forgiveness for them seventy times..' (Surah 9 : Ayah 80) so I will ask more than seventy times."
+Allah's Messenger (ﷺ) got up to offer the funeral prayer for him, but `Umar got up too and got hold of the garment of Allah's Messenger (ﷺ) and said, "O Allah's Messenger (ﷺ)! Will you offer the funeral prayer for him though your Lord has forbidden you to offer the prayer for him?"
+Allah's Messenger (ﷺ) said, "But Allah has given me the choice by saying: '(Whether you) ask forgiveness for them, or do not ask forgiveness for them; even if you ask forgiveness for them seventy times...' (Surah 9 : Ayah 80) so I will ask more than seventy times."
 `Umar said, "But he (`Abdullah bin 'Ubai) is a hypocrite!" However, Allah's Messenger (ﷺ) did offer the funeral prayer for him, whereupon Allah revealed: 'And never (O Muhammad) pray for anyone of them that dies, nor stand at his grave.' (Surah 9: Ayah 84)
 Hadith - 193
 Narrated `Umar bin Al-Khattab: When `Abdullah bin Ubai bin Salul died, Allah's Messenger (ﷺ) was called in order to offer the funeral prayer for him.
 When Allah's Messenger (ﷺ) got up (to offer the prayer), I jumped towards him and said, "O Allah's Messenger (ﷺ)! Do you offer the prayer for Ibn Ubai although he said so-and-so on such-and-such a day?" I went on mentioning his sayings.
 Allah's Messenger (ﷺ) smiled and said, "Keep away from me, O `Umar!" But when I spoke too much to him, he said, "I have been given the choice, and I have chosen (this); and if I knew that if I asked forgiveness for him more than seventy times, he would be forgiven, I would ask it for more times than that."
-So Allah's Messenger (ﷺ) offered the funeral prayer for him and then left, but he did not stay long before the two Verses of Surat-Bara'a were revealed, i.e., 'And never (O Muhammad) pray for anyone of them that dies... and died in a state of rebellion.' (Surah 9 : Ayah 84).
+So Allah's Messenger (ﷺ) offered the funeral prayer for him and then left, but he did not stay long before the two Verses of Surat-Bara'a were revealed, i.e., 'And never (O Muhammad) pray for anyone of them that dies ... and died in a state of rebellion.' (Surah 9 : Ayah 84).
 Later, I was astonished at my daring to speak like that to Allah's Messenger (ﷺ) and Allah and His Apostle know best.
 Hadith - 194
 Narrated Ibn `Umar: When `Abdullah bin Ubai died, his son `Abdullah bin `Abdullah came to Allah's Messenger (ﷺ) who gave his shirt to him and ordered him to shroud his father in it.
@@ -139,7 +139,7 @@ The Prophet (ﷺ) said, "Allah has given me the choice (or Allah has informed me
 Then he added, "I will (appeal to Allah for his sake) more than seventy times." So Allah's Messenger (ﷺ) offered the funeral prayer for him, and we too offered the prayer along with him.
 Then Allah revealed: "And never, O Muhammad, pray (funeral prayer) for anyone of them that dies, nor stand at his grave. Certainly they disbelieved in Allah and His Apostle and died in a state of rebellion." (Surah 9: Ayah 84)
 Hadith - 195
-Narrated `Abdullah bin Ka`b: I heard Ka`b bin Malik at the time he remained behind and did not join (the battle of) Tabuk, saying, "By Allah, no blessing has Allah bestowed upon me, besides my guidance to Islam, better than that of helping me speak the truth to Allah's Messenger (ﷺ), otherwise I would have told the Prophet (ﷺ) a lie and would have been ruined like those who had told a lie when the Divine Inspiration was revealed: 'They will swear by Allah to you (Muslims) when you return to them... the rebellious people.' (Surah 9: Ayat 95-96)"
+Narrated `Abdullah bin Ka`b: I heard Ka`b bin Malik at the time he remained behind and did not join (the battle of) Tabuk, saying, "By Allah, no blessing has Allah bestowed upon me, besides my guidance to Islam, better than that of helping me speak the truth to Allah's Messenger (ﷺ), otherwise I would have told the Prophet (ﷺ) a lie and would have been ruined like those who had told a lie when the Divine Inspiration was revealed: 'They will swear by Allah to you (Muslims) when you return to them ... the rebellious people.' (Surah 9: Ayat 95-96)"
 Hadith - 196
 Narrated Samura bin Jundub: Allah's Messenger (ﷺ) said, "Tonight two (visitors) came to me (in my dream) and took me to a town built with gold bricks and silver bricks.
 There we met men who, half of their bodies look like the most handsome human beings you have ever seen, and the other half the ugliest human beings you have ever seen.
@@ -168,16 +168,16 @@ Allah said: 'They will present their excuses to you (Muslims) when you return to
 Hadith - 200
 Narrated `Abdullah bin Ka`b: I heard Ka`b bin Malik talking about the story of the battle of Tabuk when he remained behind, "By Allah, I do not know anyone whom Allah has helped for telling the truth more than me.
 Since I mentioned that truth to Allah's Messenger (ﷺ), till today I have never intended to tell a lie.
-And Allah revealed to His Apostle: 'Verily! Allah has forgiven the Prophet, the Muhajirin... and be with those who are true (in words and deeds).' (Surah 9: Ayat 117-119)"
+And Allah revealed to His Apostle: 'Verily! Allah has forgiven the Prophet, the Muhajirin ... and be with those who are true (in words and deeds).' (Surah 9: Ayat 117-119)"
 Hadith - 201
 Narrated Zaid bin Thabit Al-Ansari: Who was one of those who used to write the Divine Revelation: Abu Bakr sent for me after the (heavy) casualties among the warriors (of the battle) of Yamama (where a great number of Qurra' were killed).
 `Umar was present with Abu Bakr who said, "`Umar has come to me and said, 'The people have suffered heavy casualties on the day of (the battle of) Yamama, and I am afraid that there will be more casualties among the Qurra' (those who know the Qur'an by heart) at other battle-fields, whereby a large part of the Qur'an may be lost, unless you collect it. And I am of the opinion that you should collect the Qur'an.'"
 Abu Bakr added, "I said to `Umar, 'How can I do something which Allah's Apostle has not done?' `Umar said (to me), 'By Allah, it is (really) a good thing.'
 So `Umar kept on pressing, trying to persuade me to accept his proposal, till Allah opened my bosom for it and I had the same opinion as `Umar."
-(Zaid bin Thabit added:) `Umar was sitting with him (Abu Bakr) and was not speaking me).
-"You are a wise young man and we do not suspect you (of telling lies or of forgetfulness): and you used to write the Divine Inspiration for Allah's Messenger (ﷺ). Therefore, look for the Qur'an and collect it (in one manuscript)."
+(Zaid bin Thabit added:) `Umar was sitting with him (Abu Bakr) and was not speaking to me.
+"You are a wise young man and we do not suspect you (of telling lies or of forgetfulness), and you used to write the Divine Inspiration for Allah's Messenger (ﷺ). Therefore, look for the Qur'an and collect it (in one manuscript)."
 By Allah, if he (Abu Bakr) had ordered me to shift one of the mountains (from its place) it would not have been harder for me than what he had ordered me concerning the collection of the Qur'an.
-I said to both of them, "How dare you do a thing which the Prophet (ﷺ) has not done?" Abu Bakr said, "By Allah, it is (really) a good thing." So I kept on arguing with him about it till Allah opened my bosom for that which He had opened the bosoms of Abu Bakr and `Umar.
+I said to both of them, "How dare you do a thing which the Prophet (ﷺ) has not done?" Abu Bakr said, "By Allah, it is (really) a good thing." So I kept on arguing with him about it, till Allah opened my bosom for that which He had opened the bosoms of Abu Bakr and `Umar.
 So I started locating Qur'anic material and collecting it from parchments, scapula, leaf-stalks of date palms and from the memories of men (who knew it by heart).
 I found with Khuza`ima two Verses of Surat-at-Tauba which I had not found with anybody else, (and they were): "Verily, there has come to you an Apostle (Muhammad) from amongst yourselves. It grieves him that you should receive any injury or difficulty. He (Muhammad) is ardently anxious over you (to be rightly guided)" (Surah 9 : Ayah 128).
 The manuscript on which the Qur'an was collected remained with Abu Bakr till Allah took him unto Him, and then with `Umar till Allah took him unto Him, and finally it remained with Hafsa, `Umar's daughter.


### PR DESCRIPTION
# book 65p5

no-corrections: 70, 90, 110, 126, 177, 180,

corrections: 29, 49, 62, 63, 121, 127, 147, 155,

break: 142,

missing:

?: 81,